### PR TITLE
Exit 0 on init

### DIFF
--- a/luaver
+++ b/luaver
@@ -857,4 +857,7 @@ luaver()
     __luaver_exec_command cd "${__luaver_present_dir}"
 }
 
-[ -n "$1" ] && luaver "$@"
+if [ -n "$1" ]
+then 
+    luaver "$@"
+fi


### PR DESCRIPTION
Sourcing the luaver script to initialize it in the shell always results in a non-zero exit code because of the use of a boolean test.  Changed it to an if statement.