### PR TITLE
Add linux-readline target support for 5.4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0-lux] - 2021-06-20
+
+### Added
+
+- Lua 5.4 linux-readline support
+
 ## [1.1.0] - 2017-08-16
 
 ### Added

--- a/luaver
+++ b/luaver
@@ -7,7 +7,7 @@
 #
 # MIT license http://www.opensource.org/licenses/mit-license.php
 
-__luaver_VERSION="1.1.0"
+__luaver_VERSION="1.1.0-lux"
 
 # Directories and files to be used
 

--- a/luaver
+++ b/luaver
@@ -428,6 +428,10 @@ __luaver_install_lua()
         __luaver_print "Unable to detect platform. Using default 'posix'"
         platform=posix
     else
+        if [[ "${version}" =~ 5[.]4[.][0-9]+ ]]
+        then
+            platform="${platform}-readline"
+        fi
         __luaver_print "Platform detected: ${platform}"
     fi
 

--- a/luaver
+++ b/luaver
@@ -428,7 +428,7 @@ __luaver_install_lua()
         __luaver_print "Unable to detect platform. Using default 'posix'"
         platform=posix
     else
-        if [[ "${version}" =~ 5[.]4[.][0-9]+ ]]
+        if [ -n "$('echo' "${version}" | 'awk' '/^5\.4\./')" ]
         then
             platform="${platform}-readline"
         fi


### PR DESCRIPTION
According to Lua 5.4.x's README:

> If you're running Linux, try "make linux-readline" to build the interactive Lua interpreter with handy line-editing and history capabilities.

Not a very good bash scripter, so maybe this is not the best approach.